### PR TITLE
Update plugins extension to 23.08

### DIFF
--- a/org.rncbc.qtractor.json
+++ b/org.rncbc.qtractor.json
@@ -17,7 +17,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa;dssi;lv2;vst;vst3;clap",
             "subdirectories": true,


### PR DESCRIPTION
Currently this pulls in packages using `org.freedesktop.LinuxAudio.Plugins//22.08`.
Since this package is based on `org.kde.Platform//6.6` it should pull in `23.08`
