### PR TITLE
Fix plugin version

### DIFF
--- a/org.rncbc.qtractor.json
+++ b/org.rncbc.qtractor.json
@@ -17,7 +17,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "23.08",
+            "version": "24.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa;dssi;lv2;vst;vst3;clap",
             "subdirectories": true,


### PR DESCRIPTION
The Kde 6.8 runtime is based off 24.08