### PR TITLE
A Spring'26 Release (v1.6.0)

### DIFF
--- a/org.rncbc.qtractor.json
+++ b/org.rncbc.qtractor.json
@@ -57,8 +57,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/qtractor/qtractor-1.5.12.tar.gz",
-                    "sha256": "f543bb2ec29afb0feadf739ff45fdee58f73ebb7f358f96f2f282a48aee6a783"
+                    "url": "https://downloads.sourceforge.net/qtractor/qtractor-1.6.0.tar.gz",
+                    "sha256": "d22315756963456c32a7361343eb64fb2e900baf2e62021d05ff88ba31a5b794"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
updated org.rncbc.qtractor.json;
updated shared-modules.