### PR TITLE
Update runtime to 6.11

### DIFF
--- a/org.rncbc.qtractor.json
+++ b/org.rncbc.qtractor.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.rncbc.qtractor",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.10",
+    "runtime-version": "6.11",
     "sdk": "org.kde.Sdk",
     "command": "qtractor",
     "finish-args": [
@@ -37,7 +37,6 @@
         "shared-modules/linux-audio/ladspa.json",
         "shared-modules/linux-audio/liblo.json",
         "shared-modules/linux-audio/dssi.json",
-        "shared-modules/linux-audio/lv2.json",
         "shared-modules/linux-audio/lilv.json",
         "shared-modules/linux-audio/fftw3f.json",
         "rubberband.json",


### PR DESCRIPTION
Update shared-modules: lilv brings lv2 and fluidsynth is 2.5.6